### PR TITLE
Remove load more command from pallete

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,11 +70,6 @@
         "command": "vscode-couchbase.useClusterConnection",
         "title": "Connect to Cluster",
         "category": "Couchbase"
-      },
-      {
-        "command": "vscode-couchbase.loadMore",
-        "title": "Load More",
-        "category": "Couchbase"
       }
     ],
     "menus": {


### PR DESCRIPTION
## Describe the problem is this PR solving
Removes the "Couchbase: Load more" command from the VS Code palette. This should only be available internally when loading more document in a given collection.

- Closes #33

## Short description of the changes
- Removes the "load more" from palette commands in package.json

