### PR TITLE
Improve formatting of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This Visual Studio Code extension has two features.
 
 2. Snippets 
 
+## Snippets
+
 These are useful when developing with supported Couchbase SDKs. These are: 
  * Java - [Link to Documentation](https://docs.couchbase.com/java-sdk/current/hello-world/overview.html), 
  * .NET - [Link to Documentation](https://docs.couchbase.com/dotnet-sdk/current/hello-world/overview.html), 
@@ -31,9 +33,11 @@ These are useful when developing with supported Couchbase SDKs. These are:
  * Python - [Link to Documentation](https://docs.couchbase.com/python-sdk/current/hello-world/overview.html),
  * Go - [Link to Documentation](https://docs.couchbase.com/go-sdk/current/hello-world/overview.html).
 
-## Snippets
-
 Please visit [SNIPPETS.md](SNIPPETS.md) to see a list of our snippets with descriptions and documentation for each of them.
+
+## Database Browser
+
+This is a work in progress.
 
 ## License
 Apache Software License Version 2.  See individual files for details.


### PR DESCRIPTION
## Describe the problem is this PR solving

Improve formatting of README.md, the features and snippet section don't work well.

## Short description of the changes

The features section now only says the names of the features that are in the extension.
Rather than displaying the description of the snippets in the features section, it is now shown in the snippets section.
I have created a section for the database browser that somebody with more knowledge than me could fill in.